### PR TITLE
Import changes to 2lss Higgs pt reco by object selection from 104X_dev_nano_dev to 104X_dev_nano_diff

### DIFF
--- a/TTHAnalysis/python/tools/higgsDiffCompTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffCompTTH.py
@@ -29,6 +29,9 @@ class HiggsDiffCompTTH(Module):
 
         # Independent on JES
         
+        self.out.branch('%srightlepidx'%self.label                                      , 'I')
+        self.out.branch('%swronglepidx'%self.label                                      , 'I')
+
         # Somehow dependent on JES
         for jesLabel in self.systsJEC.values():
             self.out.branch('%spTVisCrossCheck%s'%(self.label,jesLabel)                      , 'F')
@@ -39,6 +42,7 @@ class HiggsDiffCompTTH(Module):
             self.out.branch('%sdelR_lep_jm1%s'%(self.label,jesLabel)                         , 'F')
             self.out.branch('%sdelR_lep_jm2%s'%(self.label,jesLabel)                         , 'F')
             self.out.branch('%sdelR_jm1_jm2%s'%(self.label,jesLabel)                         , 'F')
+            self.out.branch('%sboth_selected_jets_matched%s'%(self.label,jesLabel)           , 'I')
             self.out.branch('%sinv_mass_jm1jm2%s'%(self.label,jesLabel)                      , 'F')
             self.out.branch('%sinv_mass_H_jets_match_plusNu%s'%(self.label,jesLabel)         , 'F')
             self.out.branch('%sinv_mass_H_jets_match%s'%(self.label,jesLabel)                , 'F')
@@ -52,10 +56,22 @@ class HiggsDiffCompTTH(Module):
             self.out.branch('%sclosestJet_ptres_ToQ2FromWFromH%s'%(self.label,jesLabel)      , 'F')
             self.out.branch('%sclosestJet_delR_ToQ1FromWFromH%s'%(self.label,jesLabel)       , 'F')
             self.out.branch('%sclosestJet_delR_ToQ2FromWFromH%s'%(self.label,jesLabel)       , 'F')
+            self.out.branch('%sclosestJet_flavour_ToQ1FromWFromH%s'%(self.label,jesLabel)    , 'F')
+            self.out.branch('%sclosestJet_flavour_ToQ2FromWFromH%s'%(self.label,jesLabel)    , 'F')
             self.out.branch('%sdelR_lep_jm_closest%s'%(self.label,jesLabel)                  , 'F')
             self.out.branch('%sdelR_lep_jm_farthest%s'%(self.label,jesLabel)                 , 'F')
             self.out.branch('%sdelR_jm_closest_jm_farthest%s'%(self.label,jesLabel)          , 'F')
-            self.out.branch('%sdelR_lep_closest_wrongjet%s'%(self.label,jesLabel)           , 'F')
+            self.out.branch('%sdelR_lep_closest_wrongjet%s'%(self.label,jesLabel)            , 'F')
+            # htt quantities
+            self.out.branch('%shtt_PtTop%s'%(self.label,jesLabel)                            , 'F')
+            self.out.branch('%shtt_MTop%s'%(self.label,jesLabel)                             , 'F')
+            self.out.branch('%shtt_PtWFromTop%s'%(self.label,jesLabel)                       , 'F')
+            self.out.branch('%shtt_MWFromTop%s'%(self.label,jesLabel)                        , 'F')
+            self.out.branch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)             , 'F')
+            self.out.branch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)             , 'F')
+            # Other quantities
+            self.out.branch('%smHrightlep%s'%(self.label,jesLabel)                           , 'F')
+            self.out.branch('%smHwronglep%s'%(self.label,jesLabel)                           , 'F')
 
     def makeVisibleHiggs(self, l, j1, j2, nu=None):
         if (not j1) or (not j2) or (not l) or (j1.Pt()>9999.) or (j2.Pt()>9999.) or (l.Pt()>9999.):
@@ -80,7 +96,10 @@ class HiggsDiffCompTTH(Module):
     def analyze(self, event):
         # Some useful input parameters
         year=getattr(event,"year")
-        btagvetoval= HiggsRecoTTHbtagwps["DeepFlav_%d_%s"%(year,self.btagDeepCSVveto)][1]
+        if self.btagDeepCSVveto in ['VL','L','M','T','VT']:
+            btagvetoval = HiggsRecoTTHbtagwps["DeepFlav_%d_%s"%(year,self.btagDeepCSVveto)][1]
+        else:
+            btagvetoval = self.btagDeepCSVveto
 
         # Input collections and maps
 
@@ -103,10 +122,58 @@ class HiggsDiffCompTTH(Module):
         pTTrueGen       = getattr(event,'%spTTrueGen'%self.label)
         pTTrueGenPlusNu = getattr(event,'%spTTrueGenPlusNu'%self.label)
         
+        allLeps     = Collection(event,"LepGood","nLepGood")
+        nFO      = getattr(event,"nLepFO_Recl")
+        selLeps    = getattr(event,"iLepFO_Recl")
+        leps   = [allLeps[selLeps[i]] for i in xrange(nFO)]
         thejets     = [x for x in Collection(event,"JetSel_Recl","nJetSel_Recl")]
         thejetsNoB     = [j for j in thejets if j.btagDeepB<btagvetoval]
-        
+        thejetsmore = [x for x in Collection(event,"Jet")]
+        thejetsphieta = [[j.phi, j.eta] for j in thejets]
+        thejetsmoreskimmed = [j for j in thejetsmore if [j.phi,j.eta] in thejetsphieta]
+
+        # Get right & wrong lepton index
+        rightlep = -99
+        wronglep = -99
+        if (len(QFromWFromH)==2 and len(LFromWFromH)==1):
+            ilist=[i[0] for i in sorted(enumerate(leps),key=lambda x:x[1].p4().DeltaR(LFromWFromH[0]))]
+            rightlep = ilist[0]
+            wronglep = ilist[-1] # last element in list, usually ilist[1] since len(leps)==2 usually
+        self.out.fillBranch('%srightlepidx'%self.label                          , rightlep    )
+        self.out.fillBranch('%swronglepidx'%self.label                          , wronglep    )
+
+        # Get higgs mass by combining gen quarks with right & wrong leptons
+        mHrightlep = -99
+        mHwronglep = -99
+        if len(QFromWFromH)==2 and len(LFromWFromH)==1:
+            mHrightlep = (leps[rightlep].p4()+QFromWFromH[0]+QFromWFromH[1]).M()
+            mHwronglep = (leps[wronglep].p4()+QFromWFromH[0]+QFromWFromH[1]).M()
+
         for jesLabel in self.systsJEC.values():
+            htt_PtTop = -99
+            htt_MTop  = -99
+            htt_PtWFromTop = -99
+            htt_MWFromTop  = -99
+            htt_HadTop_rightlep_delr = -99
+            htt_HadTop_wronglep_delr = -99
+            score = getattr(event,"BDThttTT_eventReco_mvaValue%s"%jesLabel)
+            j1top = getattr(event,"BDThttTT_eventReco_iJetSel1%s"%jesLabel)
+            j2top = getattr(event,"BDThttTT_eventReco_iJetSel2%s"%jesLabel)
+            j3top = getattr(event,"BDThttTT_eventReco_iJetSel3%s"%jesLabel)
+            if score>self.cut_BDT_rTT_score and j1top >= 0 and j2top >= 0 and j3top >= 0:
+                j1 = thejets[int(j1top)]
+                j2 = thejets[int(j2top)]
+                j3 = thejets[int(j3top)]
+                bscores = [j1.btagDeepB, j2.btagDeepB, j3.btagDeepB]
+                bindex = bscores.index(max(bscores))
+                htt_PtTop = (j1.p4()+j2.p4()+j3.p4()).Pt()
+                htt_MTop = (j1.p4()+j2.p4()+j3.p4()).M()
+                htt_PtWFromTop = (j1.p4()*(bindex!=0)+j2.p4()*(bindex!=1)+j3.p4()*(bindex!=2)).Pt()
+                htt_MWFromTop = (j1.p4()*(bindex!=0)+j2.p4()*(bindex!=1)+j3.p4()*(bindex!=2)).M()
+                if len(QFromWFromH)==2 and len(LFromWFromH)==1:
+                    htt_HadTop_rightlep_delr = (j1.p4()+j2.p4()+j3.p4()).DeltaR(leps[rightlep].p4())
+                    htt_HadTop_wronglep_delr = (j1.p4()+j2.p4()+j3.p4()).DeltaR(leps[wronglep].p4())
+
             # We need to have saved three entire collections, because the triplet selection might select different objects when JEC changes
             leptonFromHiggs = [ x.p4() for x in Collection(event,'%sleptonsFromHiggs%s'%(self.label,jesLabel),'%snLeptonsFromHiggs%s'%(self.label,jesLabel))]
             jetsFromHiggs   = [ x.p4() for x in Collection(event,'%sjetsFromHiggs%s'%(self.label,jesLabel), '%snJetsFromHiggs%s'%(self.label,jesLabel)) ]
@@ -165,10 +232,14 @@ class HiggsDiffCompTTH(Module):
             if len(QFromWFromH)==2:
                 q1, q2 = QFromWFromH
 
-                for x in thejets: # I need these rather than the jetsNoB because I want to allow matching to match the QfromH to b-jets. I need this and not jets[] because I want to access the flavour.
+                # I need these rather than the jetsNoB because I want to allow matching to match the QfromH to b-jets. 
+                # I need this and not jets[] because I want to access the flavour.
+                for _x,x in enumerate(thejets):
+#                    if x.btagDeepB > 0.3093: continue # Optionally kill > Medium B-Jets
                     j=x.p4()
                     j.SetPtEtaPhiM(getattr(x,'pt%s'%jesLabel), j.Eta(), j.Phi(), j.M()) # Correct the pt
-                    jflav = getattr(x,'hadronFlavour')
+#                    jflav = getattr(x,'hadronFlavour')
+                    jflav = getattr(thejetsmoreskimmed[_x],'partonFlavour')
                     drq1=q1.DeltaR(j)
                     drq2=q2.DeltaR(j)
                     if drq1 < dr_closestTo_q1:
@@ -178,6 +249,10 @@ class HiggsDiffCompTTH(Module):
                         dr_closestTo_q1=drq1
                         flav_closestTo_q1=jflav
                         jm1=j
+                    elif drq1 < dr_nClosestTo_q1:
+                        dr_nClosestTo_q1=drq1
+                        flav_nClosestTo_q1=jflav
+                        jnm1=j
                     if drq2 < dr_closestTo_q2:
                         dr_nClosestTo_q2=dr_closestTo_q2
                         flav_nClosestTo_q2=flav_closestTo_q2
@@ -185,6 +260,10 @@ class HiggsDiffCompTTH(Module):
                         dr_closestTo_q2=drq2
                         flav_closestTo_q2=jflav
                         jm2=j
+                    elif drq2 < dr_nClosestTo_q2:
+                        dr_nClosestTo_q2=drq2
+                        flav_nClosestTo_q2=jflav
+                        jnm2=j
 
                 # Disentangle cases where the same jet matches both jets
                 # choice: pick the closest next-to-closest as the second jet
@@ -210,9 +289,11 @@ class HiggsDiffCompTTH(Module):
             self.out.fillBranch('%sclosestJet_pt_ToQ1FromWFromH%s'%(self.label,jesLabel)         , jm1.Pt()                   if jm1 else -99.)
             self.out.fillBranch('%sclosestJet_ptres_ToQ1FromWFromH%s'%(self.label,jesLabel)      , (jm1.Pt()-q1.Pt())/q1.Pt() if jm1 else -99.)
             self.out.fillBranch('%sclosestJet_delR_ToQ1FromWFromH%s'%(self.label,jesLabel)       , dr_closestTo_q1            if jm1 else -99.)
+            self.out.fillBranch('%sclosestJet_flavour_ToQ1FromWFromH%s'%(self.label,jesLabel)    , flav_closestTo_q1          if jm1 else -99.)
             self.out.fillBranch('%sclosestJet_pt_ToQ2FromWFromH%s'%(self.label,jesLabel)         , jm2.Pt()                   if jm2 else -99.)
             self.out.fillBranch('%sclosestJet_ptres_ToQ2FromWFromH%s'%(self.label,jesLabel)      , (jm2.Pt()-q2.Pt())/q2.Pt() if jm2 else -99.)
             self.out.fillBranch('%sclosestJet_delR_ToQ2FromWFromH%s'%(self.label,jesLabel)       , dr_closestTo_q2            if jm2 else -99.)
+            self.out.fillBranch('%sclosestJet_flavour_ToQ2FromWFromH%s'%(self.label,jesLabel)    , flav_closestTo_q2          if jm2 else -99.)
             
             # Now apply thresholds: if they don't satisfy matching thresholds, wipe them out
             # Since I am at it, count how many partons have a jet matched to them
@@ -233,7 +314,10 @@ class HiggsDiffCompTTH(Module):
             # Compare the matched jets and the reco jets
             # First I want to write down a few quantities
             visHiggs_matched, visHiggsPlusNu_matched = self.makeVisibleHiggs(leptonFromHiggs, jm1, jm2, NuFromWFromH[0] if len(NuFromWFromH)==1 else None)
-
+            both_selected_jets_matched = 1 if (jm1 and jm2 and len(jetsFromHiggs)==2 and \
+            ((abs(jm1.Pt()-jetsFromHiggs[0].Pt())<1e-10 and abs(jm2.Pt()-jetsFromHiggs[1].Pt())<1e-10) or \
+            (abs(jm2.Pt()-jetsFromHiggs[0].Pt())<1e-10 and abs(jm1.Pt()-jetsFromHiggs[1].Pt())<1e-10))) else 0
+            self.out.fillBranch('%sboth_selected_jets_matched%s'%(self.label,jesLabel) , both_selected_jets_matched)
             self.out.fillBranch('%sinv_mass_jm1jm2%s'%(self.label,jesLabel)                      , (jm1+jm2).M()               if (jm1 and jm2)             else -99.)
             self.out.fillBranch('%sinv_mass_H_jets_match%s'%(self.label,jesLabel)                , visHiggs_matched.M()        if visHiggs_matched          else -99.)
             self.out.fillBranch('%sinv_mass_H_jets_match_plusNu%s'%(self.label,jesLabel)         , visHiggsPlusNu_matched.M()  if visHiggsPlusNu_matched    else -99.)
@@ -256,7 +340,9 @@ class HiggsDiffCompTTH(Module):
             dr_l_closestWrong=9999.
             j_closestWrong=None
             if leptonFromHiggs:
-                for x in thejets: # I need these rather than the jetsNoB because I want to allow matching to match the QfromH to b-jets. I need this and not jets[] because I want to access the flavour.
+                # I need these rather than the jetsNoB because I want to allow matching to match the QfromH to b-jets.
+                # I need this and not jets[] because I want to access the flavour.
+                for x in thejets:
                     j=x.p4()
                     j.SetPtEtaPhiM(getattr(x,'pt%s'%jesLabel), j.Eta(), j.Phi(), j.M()) # Correct the pt. Not really needed, but added just in case pt is accessed in later edits
                     if j==jm1 or j==jm2:
@@ -268,6 +354,18 @@ class HiggsDiffCompTTH(Module):
             
             self.out.fillBranch('%sdelR_lep_closest_wrongjet%s'%(self.label,jesLabel), leptonFromHiggs.DeltaR(j_closestWrong) if j_closestWrong else -99.)
 
+            # htt quantities
+            self.out.fillBranch('%shtt_PtTop%s'%(self.label,jesLabel)  , htt_PtTop)
+            self.out.fillBranch('%shtt_MTop%s'%(self.label,jesLabel)  , htt_MTop)
+            self.out.fillBranch('%shtt_PtWFromTop%s'%(self.label,jesLabel)  , htt_PtWFromTop)
+            self.out.fillBranch('%shtt_MWFromTop%s'%(self.label,jesLabel)  , htt_MWFromTop)
+            self.out.fillBranch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)  , htt_HadTop_rightlep_delr)
+            self.out.fillBranch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)  , htt_HadTop_wronglep_delr)
+
+            # Other quantities
+            self.out.fillBranch('%smHrightlep%s'%(self.label,jesLabel)  ,  mHrightlep)
+            self.out.fillBranch('%smHwronglep%s'%(self.label,jesLabel)  ,  mHwronglep)
+
         return True
 
 
@@ -278,6 +376,7 @@ higgsDiffCompTTH = lambda : HiggsDiffCompTTH(label="Hreco_",
                                              use_Wmass_constraint = True,
                                              attemptDisentangling = True,
                                              btagDeepCSVveto = 'M', # or 'M'
+                                             doSystJEC=True,
                                              useTopTagger=False)
 
 higgsDiffCompTTH_noWmassConstraint = lambda : HiggsDiffCompTTH(label="Hreco_",
@@ -287,4 +386,5 @@ higgsDiffCompTTH_noWmassConstraint = lambda : HiggsDiffCompTTH(label="Hreco_",
                                              use_Wmass_constraint = False,
                                              attemptDisentangling = True,
                                              btagDeepCSVveto = 'M', # or 'M'
+                                             doSystJEC=True,
                                              useTopTagger=False)

--- a/TTHAnalysis/python/tools/higgsDiffCompTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffCompTTH.py
@@ -141,7 +141,7 @@ class HiggsDiffCompTTH(Module):
         if len(QFromWFromH)==2 and len(LFromWFromH)==1:
             mHrightlep = (leps[rightlep].p4()+QFromWFromH[0]+QFromWFromH[1]).M()
             mHwronglep = (leps[wronglep].p4()+QFromWFromH[0]+QFromWFromH[1]).M()
-
+        
         for jesLabel in self.systsJEC.values():
 
             # We need to have saved three entire collections, because the triplet selection might select different objects when JEC changes
@@ -284,6 +284,7 @@ class HiggsDiffCompTTH(Module):
             # Compare the matched jets and the reco jets
             # First I want to write down a few quantities
             visHiggs_matched, visHiggsPlusNu_matched = self.makeVisibleHiggs(leptonFromHiggs, jm1, jm2, NuFromWFromH[0] if len(NuFromWFromH)==1 else None)
+
             both_selected_jets_matched = 1 if (jm1 and jm2 and len(jetsFromHiggs)==2 and \
             ((abs(jm1.Pt()-jetsFromHiggs[0].Pt())<1e-10 and abs(jm2.Pt()-jetsFromHiggs[1].Pt())<1e-10) or \
             (abs(jm2.Pt()-jetsFromHiggs[0].Pt())<1e-10 and abs(jm1.Pt()-jetsFromHiggs[1].Pt())<1e-10))) else 0

--- a/TTHAnalysis/python/tools/higgsDiffCompTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffCompTTH.py
@@ -62,13 +62,6 @@ class HiggsDiffCompTTH(Module):
             self.out.branch('%sdelR_lep_jm_farthest%s'%(self.label,jesLabel)                 , 'F')
             self.out.branch('%sdelR_jm_closest_jm_farthest%s'%(self.label,jesLabel)          , 'F')
             self.out.branch('%sdelR_lep_closest_wrongjet%s'%(self.label,jesLabel)            , 'F')
-            # htt quantities
-            self.out.branch('%shtt_PtTop%s'%(self.label,jesLabel)                            , 'F')
-            self.out.branch('%shtt_MTop%s'%(self.label,jesLabel)                             , 'F')
-            self.out.branch('%shtt_PtWFromTop%s'%(self.label,jesLabel)                       , 'F')
-            self.out.branch('%shtt_MWFromTop%s'%(self.label,jesLabel)                        , 'F')
-            self.out.branch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)             , 'F')
-            self.out.branch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)             , 'F')
             # Other quantities
             self.out.branch('%smHrightlep%s'%(self.label,jesLabel)                           , 'F')
             self.out.branch('%smHwronglep%s'%(self.label,jesLabel)                           , 'F')
@@ -150,29 +143,6 @@ class HiggsDiffCompTTH(Module):
             mHwronglep = (leps[wronglep].p4()+QFromWFromH[0]+QFromWFromH[1]).M()
 
         for jesLabel in self.systsJEC.values():
-            htt_PtTop = -99
-            htt_MTop  = -99
-            htt_PtWFromTop = -99
-            htt_MWFromTop  = -99
-            htt_HadTop_rightlep_delr = -99
-            htt_HadTop_wronglep_delr = -99
-            score = getattr(event,"BDThttTT_eventReco_mvaValue%s"%jesLabel)
-            j1top = getattr(event,"BDThttTT_eventReco_iJetSel1%s"%jesLabel)
-            j2top = getattr(event,"BDThttTT_eventReco_iJetSel2%s"%jesLabel)
-            j3top = getattr(event,"BDThttTT_eventReco_iJetSel3%s"%jesLabel)
-            if score>self.cut_BDT_rTT_score and j1top >= 0 and j2top >= 0 and j3top >= 0:
-                j1 = thejets[int(j1top)]
-                j2 = thejets[int(j2top)]
-                j3 = thejets[int(j3top)]
-                bscores = [j1.btagDeepB, j2.btagDeepB, j3.btagDeepB]
-                bindex = bscores.index(max(bscores))
-                htt_PtTop = (j1.p4()+j2.p4()+j3.p4()).Pt()
-                htt_MTop = (j1.p4()+j2.p4()+j3.p4()).M()
-                htt_PtWFromTop = (j1.p4()*(bindex!=0)+j2.p4()*(bindex!=1)+j3.p4()*(bindex!=2)).Pt()
-                htt_MWFromTop = (j1.p4()*(bindex!=0)+j2.p4()*(bindex!=1)+j3.p4()*(bindex!=2)).M()
-                if len(QFromWFromH)==2 and len(LFromWFromH)==1:
-                    htt_HadTop_rightlep_delr = (j1.p4()+j2.p4()+j3.p4()).DeltaR(leps[rightlep].p4())
-                    htt_HadTop_wronglep_delr = (j1.p4()+j2.p4()+j3.p4()).DeltaR(leps[wronglep].p4())
 
             # We need to have saved three entire collections, because the triplet selection might select different objects when JEC changes
             leptonFromHiggs = [ x.p4() for x in Collection(event,'%sleptonsFromHiggs%s'%(self.label,jesLabel),'%snLeptonsFromHiggs%s'%(self.label,jesLabel))]
@@ -353,14 +323,6 @@ class HiggsDiffCompTTH(Module):
                         j_closestWrong=j
             
             self.out.fillBranch('%sdelR_lep_closest_wrongjet%s'%(self.label,jesLabel), leptonFromHiggs.DeltaR(j_closestWrong) if j_closestWrong else -99.)
-
-            # htt quantities
-            self.out.fillBranch('%shtt_PtTop%s'%(self.label,jesLabel)  , htt_PtTop)
-            self.out.fillBranch('%shtt_MTop%s'%(self.label,jesLabel)  , htt_MTop)
-            self.out.fillBranch('%shtt_PtWFromTop%s'%(self.label,jesLabel)  , htt_PtWFromTop)
-            self.out.fillBranch('%shtt_MWFromTop%s'%(self.label,jesLabel)  , htt_MWFromTop)
-            self.out.fillBranch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)  , htt_HadTop_rightlep_delr)
-            self.out.fillBranch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)  , htt_HadTop_wronglep_delr)
 
             # Other quantities
             self.out.fillBranch('%smHrightlep%s'%(self.label,jesLabel)  ,  mHrightlep)

--- a/TTHAnalysis/python/tools/higgsDiffCompTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffCompTTH.py
@@ -28,7 +28,6 @@ class HiggsDiffCompTTH(Module):
         self.out = wrappedOutputTree
 
         # Independent on JES
-        
         self.out.branch('%srightlepidx'%self.label                                      , 'I')
         self.out.branch('%swronglepidx'%self.label                                      , 'I')
 
@@ -205,10 +204,10 @@ class HiggsDiffCompTTH(Module):
                 # I need these rather than the jetsNoB because I want to allow matching to match the QfromH to b-jets. 
                 # I need this and not jets[] because I want to access the flavour.
                 for _x,x in enumerate(thejets):
-#                    if x.btagDeepB > 0.3093: continue # Optionally kill > Medium B-Jets
+                    #if x.btagDeepB > 0.3093: continue # Optionally kill > Medium B-Jets
                     j=x.p4()
                     j.SetPtEtaPhiM(getattr(x,'pt%s'%jesLabel), j.Eta(), j.Phi(), j.M()) # Correct the pt
-#                    jflav = getattr(x,'hadronFlavour')
+                    #jflav = getattr(x,'hadronFlavour')
                     jflav = getattr(thejetsmoreskimmed[_x],'partonFlavour')
                     drq1=q1.DeltaR(j)
                     drq2=q2.DeltaR(j)
@@ -324,7 +323,6 @@ class HiggsDiffCompTTH(Module):
                         j_closestWrong=j
             
             self.out.fillBranch('%sdelR_lep_closest_wrongjet%s'%(self.label,jesLabel), leptonFromHiggs.DeltaR(j_closestWrong) if j_closestWrong else -99.)
-
             # Other quantities
             self.out.fillBranch('%smHrightlep%s'%(self.label,jesLabel)  ,  mHrightlep)
             self.out.fillBranch('%smHwronglep%s'%(self.label,jesLabel)  ,  mHwronglep)

--- a/TTHAnalysis/python/tools/higgsDiffCompTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffCompTTH.py
@@ -30,7 +30,6 @@ class HiggsDiffCompTTH(Module):
         # Independent on JES
         self.out.branch('%srightlepidx'%self.label                                      , 'I')
         self.out.branch('%swronglepidx'%self.label                                      , 'I')
-
         # Somehow dependent on JES
         for jesLabel in self.systsJEC.values():
             self.out.branch('%spTVisCrossCheck%s'%(self.label,jesLabel)                      , 'F')
@@ -142,7 +141,6 @@ class HiggsDiffCompTTH(Module):
             mHwronglep = (leps[wronglep].p4()+QFromWFromH[0]+QFromWFromH[1]).M()
         
         for jesLabel in self.systsJEC.values():
-
             # We need to have saved three entire collections, because the triplet selection might select different objects when JEC changes
             leptonFromHiggs = [ x.p4() for x in Collection(event,'%sleptonsFromHiggs%s'%(self.label,jesLabel),'%snLeptonsFromHiggs%s'%(self.label,jesLabel))]
             jetsFromHiggs   = [ x.p4() for x in Collection(event,'%sjetsFromHiggs%s'%(self.label,jesLabel), '%snJetsFromHiggs%s'%(self.label,jesLabel)) ]

--- a/TTHAnalysis/python/tools/higgsDiffGenTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffGenTTH.py
@@ -19,7 +19,12 @@ class HiggsDiffGenTTH(Module):
         # Particle counters
         self.out.branch('%snHiggses'%self.label         , 'I')
         self.out.branch('%snTfromhardprocess'%self.label, 'I')
+        self.out.branch('%snHadT'%self.label            , 'I')
+        self.out.branch('%snLepT'%self.label            , 'I')
+        self.out.branch('%snWFromHadT'%self.label       , 'I')
+        self.out.branch('%snWFromLepT'%self.label       , 'I')
         self.out.branch('%snWFromH'%self.label          , 'I')
+        self.out.branch('%snHadWFromH'%self.label       , 'I')
         self.out.branch('%snWFromT'%self.label          , 'I')
         self.out.branch('%snQFromW'%self.label          , 'I')
         self.out.branch('%snGenLep'%self.label          , 'I')
@@ -30,13 +35,31 @@ class HiggsDiffGenTTH(Module):
         self.out.branch('%snQFromWFromT'%self.label     , 'I')
         self.out.branch('%snLFromWFromH'%self.label     , 'I')
         self.out.branch('%snLFromWFromT'%self.label     , 'I')
+        self.out.branch('%snTauFromH'%self.label        , 'I')
+        self.out.branch('%snhFromTauFromH'%self.label   , 'I')
+        self.out.branch('%snLFromTauFromH'%self.label   , 'I')
+        self.out.branch('%snNuFromTauFromH'%self.label  , 'I')
+        self.out.branch('%snTNuFromTauFromH'%self.label , 'I')
+        self.out.branch('%snZFromH'%self.label          , 'I')
+        self.out.branch('%snQFromZFromH'%self.label     , 'I')
+        self.out.branch('%snLFromZFromH'%self.label     , 'I')
+        self.out.branch('%snNuFromZFromH'%self.label    , 'I')
+        self.out.branch('%snTauFromWFromH'%self.label   , 'I')
+        self.out.branch('%snLFromTauFromWFromH'%self.label  , 'I')
+        self.out.branch('%snNuFromTauFromWFromH'%self.label , 'I')
+        self.out.branch('%snhFromTauFromWFromH'%self.label  , 'I')
 
         # Although we expect a maximum of 2 objects per array, we allow for 4 of them to be stored, for safety and later checks
         for suffix in ["_pt", "_eta", "_phi", "_mass"]:
             
             self.out.branch('%sHiggses%s'%(self.label,suffix)          , 'F', 4, '%snHiggses'%self.label         ) 
             self.out.branch('%sTfromhardprocess%s'%(self.label,suffix) , 'F', 4, '%snTfromhardprocess'%self.label) 
+            self.out.branch('%sHadT%s'%(self.label,suffix)             , 'F', 4, '%snHadT'%self.label            ) 
+            self.out.branch('%sLepT%s'%(self.label,suffix)             , 'F', 4, '%snLepT'%self.label            ) 
+            self.out.branch('%sWFromHadT%s'%(self.label,suffix)        , 'F', 4, '%snWFromHadT'%self.label       ) 
+            self.out.branch('%sWFromLepT%s'%(self.label,suffix)        , 'F', 4, '%snWFromLepT'%self.label       ) 
             self.out.branch('%sWFromH%s'%(self.label,suffix)           , 'F', 4, '%snWFromH'%self.label          ) 
+            self.out.branch('%sHadWFromH%s'%(self.label,suffix)        , 'F', 4, '%snHadWFromH'%self.label       ) 
             self.out.branch('%sWFromT%s'%(self.label,suffix)           , 'F', 4, '%snWFromT'%self.label          ) 
             self.out.branch('%sQFromW%s'%(self.label,suffix)           , 'F', 4, '%snQFromW'%self.label          ) 
             self.out.branch('%sGenLep%s'%(self.label,suffix)           , 'F', 4, '%snGenLep'%self.label          ) 
@@ -47,26 +70,52 @@ class HiggsDiffGenTTH(Module):
             self.out.branch('%sQFromWFromT%s'%(self.label,suffix)      , 'F', 4, '%snQFromWFromT'%self.label     ) 
             self.out.branch('%sLFromWFromH%s'%(self.label,suffix)      , 'F', 4, '%snLFromWFromH'%self.label     ) 
             self.out.branch('%sLFromWFromT%s'%(self.label,suffix)      , 'F', 4, '%snLFromWFromT'%self.label     ) 
+            self.out.branch('%sTauFromH%s'%(self.label,suffix)         , 'F', 4, '%snTauFromH'%self.label        ) 
+            self.out.branch('%shFromTauFromH%s'%(self.label,suffix)    , 'F', 4, '%snhFromTauFromH'%self.label   ) 
+            self.out.branch('%sLFromTauFromH%s'%(self.label,suffix)    , 'F', 4, '%snLFromTauFromH'%self.label   ) 
+            self.out.branch('%sNuFromTauFromH%s'%(self.label,suffix)   , 'F', 4, '%snNuFromTauFromH'%self.label  ) 
+            self.out.branch('%sTNuFromTauFromH%s'%(self.label,suffix)  , 'F', 4, '%snTNuFromTauFromH'%self.label ) 
+            self.out.branch('%sZFromH%s'%(self.label,suffix)           , 'F', 4, '%snZFromH'%self.label          ) 
+            self.out.branch('%sQFromZFromH%s'%(self.label,suffix)      , 'F', 4, '%snQFromZFromH'%self.label     ) 
+            self.out.branch('%sLFromZFromH%s'%(self.label,suffix)      , 'F', 4, '%snLFromZFromH'%self.label     ) 
+            self.out.branch('%sNuFromZFromH%s'%(self.label,suffix)     , 'F', 4, '%snNuFromZFromH'%self.label    ) 
+            self.out.branch('%sTauFromWFromH%s'%(self.label,suffix)    , 'F', 4, '%snTaruFromWFromH'%self.label  ) 
+            self.out.branch('%sLFromTauFromWFromH%s'%(self.label,suffix)   , 'F', 4, '%snLFromTauFromWFromH'%self.label   )
+            self.out.branch('%sNuFromTauFromWFromH%s'%(self.label,suffix)  , 'F', 4, '%snNuFromTauFromWFromH'%self.label  )
+            self.out.branch('%shFromTauFromWFromH%s'%(self.label,suffix)   , 'F', 4, '%snhFromTauFromWFromH'%self.label   )
+
         # Some precomputed quantities of interest
 
         self.out.branch('%spTHgen'%self.label            , 'F')
         self.out.branch('%spTtgen'%self.label            , 'F', 4, '%snTfromhardprocess'%self.label)
         self.out.branch('%sinv_mass_q1_q2'%self.label    , 'F')
         self.out.branch('%sdelR_partonsFromH'%self.label , 'F')
+        self.out.branch('%spt_partonsFromH'%self.label   , 'F')
         self.out.branch('%squark1pT'%self.label          , 'F')
         self.out.branch('%squark2pT'%self.label          , 'F')
+        self.out.branch('%squark1Eta'%self.label         , 'F')
+        self.out.branch('%squark2Eta'%self.label         , 'F')
+        self.out.branch('%squark1Flavour'%self.label     , 'F')
+        self.out.branch('%squark2Flavour'%self.label     , 'F')
         self.out.branch('%sdelR_H_q1l'%self.label        , 'F')
         self.out.branch('%sdelR_H_q2l'%self.label        , 'F')
         self.out.branch('%spTTrueGen'%self.label         , 'F')
+        self.out.branch('%sMTrueGen'%self.label          , 'F')
         self.out.branch('%spTTrueGenPlusNu'%self.label   , 'F')
         
     def analyze(self, event):
+
         # Input collections and maps
         genpar = Collection(event,"GenPart","nGenPart") 
         
         Higgses          = []
         Tfromhardprocess = []
+        HadT             = []
+        LepT             = []
+        WFromHadT        = []
+        WFromLepT        = []
         WFromH           = []
+        HadWFromH        = []
         WFromT           = []
         QFromW           = []
         GenLep           = []
@@ -77,6 +126,22 @@ class HiggsDiffGenTTH(Module):
         QFromWFromT      = []
         LFromWFromH      = []
         LFromWFromT      = []
+
+        TauFromH         = []
+        hFromTauFromH    = []
+        LFromTauFromH    = []
+        NuFromTauFromH   = []
+        TNuFromTauFromH  = []
+
+        ZFromH           = []
+        QFromZFromH      = []
+        LFromZFromH      = []
+        NuFromZFromH     = []
+
+        TauFromWFromH       = []
+        LFromTauFromWFromH  = []
+        NuFromTauFromWFromH = []
+        hFromTauFromWFromH  = []
 
         for part in genpar:
             # higgs
@@ -128,12 +193,16 @@ class HiggsDiffGenTTH(Module):
                         if self.debug: print "the mother of this W is a Higgs"
                         
             # neutrino from W from top
-            if abs(part.pdgId) in [12, 14]:
+            if abs(part.pdgId) in [12, 14, 16]:
                 if self.debug: print "it is a neutrino"
                 if part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 24: 
                     if self.debug: print "the mother of this neutrino is W+ or W-"
-                    if abs(genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId) == 6:
+                    mpart = genpar[part.genPartIdxMother]
+                    while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 24): mpart = genpar[mpart.genPartIdxMother]
+                    if abs(genpar[mpart.genPartIdxMother].pdgId) == 6:
                         NuFromWFromT.append(part)
+                        if mpart not in WFromLepT: WFromLepT.append(mpart)
+                        if genpar[mpart.genPartIdxMother] not in LepT: LepT.append(genpar[mpart.genPartIdxMother])
                         if self.debug: print "the mother of this W is a top"
         
             # quarks from W from H
@@ -144,15 +213,18 @@ class HiggsDiffGenTTH(Module):
                     and genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId == 25
                     and genpar[part.genPartIdxMother].statusFlags &(1 << diffUtils.statusFlagsMap['isHardProcess'])):
                     QFromWFromH.append(part)
+                    if genpar[part.genPartIdxMother] not in HadWFromH: HadWFromH.append(genpar[part.genPartIdxMother])
                     if self.debug: print "the mother of this hard W is a hard Higgs"
 
             # quarks from W from T 
-            if (abs(part.pdgId) in [1,2,3,4,5,6] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 24 
-                     and genpar[part.genPartIdxMother].statusFlags &(1 << diffUtils.statusFlagsMap['isHardProcess'])):
+            if (abs(part.pdgId) in [1,2,3,4,5,6] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 24): 
                 if self.debug: print "it is a quark coming from a hard W"
-                if (genpar[genpar[part.genPartIdxMother].genPartIdxMother].genPartIdxMother >= 0 and abs(genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId) == 6
-                        and genpar[part.genPartIdxMother].statusFlags &(1 << diffUtils.statusFlagsMap['isHardProcess'])):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 24): mpart = genpar[mpart.genPartIdxMother]
+                if abs(genpar[mpart.genPartIdxMother].pdgId) == 6:
                     QFromWFromT.append(part)
+                    if mpart not in WFromHadT: WFromHadT.append(mpart)
+                    if genpar[mpart.genPartIdxMother] not in HadT: HadT.append(genpar[mpart.genPartIdxMother])
                     if self.debug: print "the mother of this hard W is a hard top"
 
             # leptons (excl. taus) from W from H 
@@ -175,6 +247,101 @@ class HiggsDiffGenTTH(Module):
                     LFromWFromT.append(part)
                     if self.debug: print "the mother of this W is a hard top"
         
+            # Tau from H
+            if (abs(part.pdgId) in [15] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==25):
+                TauFromH.append(part)
+                if self.debug: print "it is a hard tau coming from a higgs"
+
+            # pion / kaon from tau from H
+            if (abs(part.pdgId) in [111,211,311,321] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 25):
+                    hFromTauFromH.append(part)
+                    if self.debug: print "it is a pion or kaon coming from a hard tau from a higgs"
+
+            # Lepton from tau from H
+            if (abs(part.pdgId) in [11,13] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 25):
+                    LFromTauFromH.append(part)
+                    if self.debug: print "it is a lepton coming from a hard tau from a higgs"
+
+            # lnu from tau from H
+            if (abs(part.pdgId) in [12,14] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 25):
+                    NuFromTauFromH.append(part)
+                    if self.debug: print "it is a lepton neutrino coming from a hard tau from a higgs"
+
+            # tnu from tau from H
+            if (abs(part.pdgId) in [16] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 25):
+                    TNuFromTauFromH.append(part)
+                    if self.debug: print "it is a tau neutrino coming from a hard tau from a higgs"
+
+            # Z from H
+            if (abs(part.pdgId) in [23] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==25):
+                ZFromH.append(part)
+                if self.debug: print "it is a hard Z coming from a higgs"
+
+            # Q from Z from H
+            if (abs(part.pdgId) in [1,2,3,4,5,6] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==23):
+                if (genpar[part.genPartIdxMother].genPartIdxMother >= 0 and abs(genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId)==25):
+                    QFromZFromH.append(part)
+                    if self.debug: print "it is a quark coming from a hard Z from a higgs"
+
+            # L from Z from H
+            if (abs(part.pdgId) in [11,13] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==23):
+                if (genpar[part.genPartIdxMother].genPartIdxMother >= 0 and abs(genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId)==25):
+                    LFromZFromH.append(part)
+                    if self.debug: print "it is a lepton coming from a hard Z from a higgs"
+
+            # Nu from Z from H
+            if (abs(part.pdgId) in [12,14] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId)==23):
+                if (genpar[part.genPartIdxMother].genPartIdxMother >= 0 and abs(genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId)==25):
+                    NuFromZFromH.append(part)
+                    if self.debug: print "it is a lepton neutrino coming from a hard Z from a higgs"
+
+            # Tau from W from H
+            if (abs(part.pdgId) in [15] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 24):
+                if (genpar[part.genPartIdxMother].genPartIdxMother >= 0 and abs(genpar[genpar[part.genPartIdxMother].genPartIdxMother].pdgId)==25):
+                    TauFromWFromH.append(part)
+                    if self.debug: print "it is a tau coming from a hard W from a higgs"
+
+            # L from tau from W from H
+            if (abs(part.pdgId) in [11,13] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 24
+                        and genpar[mpart.genPartIdxMother].genPartIdxMother >= 0
+                        and abs(genpar[genpar[mpart.genPartIdxMother].genPartIdxMother].pdgId) == 25):
+                    LFromTauFromWFromH.append(part)
+                    if self.debug: print "it is a lepton coming from a tau from a hard W from a higgs"
+
+            # Nu from tau from W from H
+            if (abs(part.pdgId) in [12,14] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 24
+                        and genpar[mpart.genPartIdxMother].genPartIdxMother >= 0
+                        and abs(genpar[genpar[mpart.genPartIdxMother].genPartIdxMother].pdgId) == 25):
+                    NuFromTauFromWFromH.append(part)
+                    if self.debug: print "it is a lepton neutrino coming from a tau from a hard W from a higgs"
+
+            # pion / kaon from tau from W from H
+            if (abs(part.pdgId) in [111,211,311,321] and part.genPartIdxMother >= 0 and abs(genpar[part.genPartIdxMother].pdgId) == 15):
+                mpart = genpar[part.genPartIdxMother]
+                while (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 15): mpart = genpar[mpart.genPartIdxMother]
+                if (mpart.genPartIdxMother >= 0 and abs(genpar[mpart.genPartIdxMother].pdgId) == 24
+                        and genpar[mpart.genPartIdxMother].genPartIdxMother >= 0
+                        and abs(genpar[genpar[mpart.genPartIdxMother].genPartIdxMother].pdgId) == 25):
+                    hFromTauFromWFromH.append(part)
+                    if self.debug: print "it is a pion or kaon coming from a tau from a hard W from a higgs"
 
             if self.debug:
                 # taus
@@ -216,7 +383,12 @@ class HiggsDiffGenTTH(Module):
 
         self.out.fillBranch('%snHiggses'%self.label         , len(Higgses))
         self.out.fillBranch('%snTfromhardprocess'%self.label, len(Tfromhardprocess))
+        self.out.fillBranch('%snHadT'%self.label            , len(HadT))
+        self.out.fillBranch('%snLepT'%self.label            , len(LepT))
+        self.out.fillBranch('%snWFromHadT'%self.label       , len(WFromHadT))
+        self.out.fillBranch('%snWFromLepT'%self.label       , len(WFromLepT))
         self.out.fillBranch('%snWFromH'%self.label          , len(WFromH))
+        self.out.fillBranch('%snHadWFromH'%self.label       , len(HadWFromH))
         self.out.fillBranch('%snWFromT'%self.label          , len(WFromT))
         self.out.fillBranch('%snQFromW'%self.label          , len(QFromW))
         self.out.fillBranch('%snGenLep'%self.label          , len(GenLep))
@@ -227,10 +399,28 @@ class HiggsDiffGenTTH(Module):
         self.out.fillBranch('%snQFromWFromT'%self.label     , len(QFromWFromT))
         self.out.fillBranch('%snLFromWFromH'%self.label     , len(LFromWFromH))
         self.out.fillBranch('%snLFromWFromT'%self.label     , len(LFromWFromT)) 
+        self.out.fillBranch('%snTauFromH'%self.label        , len(TauFromH))
+        self.out.fillBranch('%snhFromTauFromH'%self.label   , len(hFromTauFromH))
+        self.out.fillBranch('%snLFromTauFromH'%self.label   , len(LFromTauFromH))
+        self.out.fillBranch('%snNuFromTauFromH'%self.label  , len(NuFromTauFromH))
+        self.out.fillBranch('%snTNuFromTauFromH'%self.label , len(TNuFromTauFromH))
+        self.out.fillBranch('%snZFromH'%self.label          , len(ZFromH))
+        self.out.fillBranch('%snQFromZFromH'%self.label     , len(QFromZFromH))
+        self.out.fillBranch('%snLFromZFromH'%self.label     , len(LFromZFromH))
+        self.out.fillBranch('%snNuFromZFromH'%self.label    , len(NuFromZFromH))
+        self.out.fillBranch('%snTauFromWFromH'%self.label   , len(TauFromWFromH))
+        self.out.fillBranch('%snLFromTauFromWFromH'%self.label  , len(LFromTauFromWFromH))
+        self.out.fillBranch('%snNuFromTauFromWFromH'%self.label , len(NuFromTauFromWFromH))
+        self.out.fillBranch('%snhFromTauFromWFromH'%self.label  , len(hFromTauFromWFromH))
 
         self.out.fillBranch('%sHiggses_pt'%self.label          , [ part.p4().Pt() for part in Higgses         ]) 
         self.out.fillBranch('%sTfromhardprocess_pt'%self.label , [ part.p4().Pt() for part in Tfromhardprocess]) 
+        self.out.fillBranch('%sHadT_pt'%self.label             , [ part.p4().Pt() for part in HadT            ]) 
+        self.out.fillBranch('%sLepT_pt'%self.label             , [ part.p4().Pt() for part in LepT            ]) 
+        self.out.fillBranch('%sWFromHadT_pt'%self.label        , [ part.p4().Pt() for part in WFromHadT       ]) 
+        self.out.fillBranch('%sWFromLepT_pt'%self.label        , [ part.p4().Pt() for part in WFromLepT       ]) 
         self.out.fillBranch('%sWFromH_pt'%self.label           , [ part.p4().Pt() for part in WFromH          ]) 
+        self.out.fillBranch('%sHadWFromH_pt'%self.label        , [ part.p4().Pt() for part in HadWFromH       ]) 
         self.out.fillBranch('%sWFromT_pt'%self.label           , [ part.p4().Pt() for part in WFromT          ]) 
         self.out.fillBranch('%sQFromW_pt'%self.label           , [ part.p4().Pt() for part in QFromW          ]) 
         self.out.fillBranch('%sGenLep_pt'%self.label           , [ part.p4().Pt() for part in GenLep          ]) 
@@ -241,10 +431,28 @@ class HiggsDiffGenTTH(Module):
         self.out.fillBranch('%sQFromWFromT_pt'%self.label      , [ part.p4().Pt() for part in QFromWFromT     ]) 
         self.out.fillBranch('%sLFromWFromH_pt'%self.label      , [ part.p4().Pt() for part in LFromWFromH     ]) 
         self.out.fillBranch('%sLFromWFromT_pt'%self.label      , [ part.p4().Pt() for part in LFromWFromT     ]) 
+        self.out.fillBranch('%sTauFromH_pt'%self.label         , [ part.p4().Pt() for part in TauFromH        ]) 
+        self.out.fillBranch('%shFromTauFromH_pt'%self.label    , [ part.p4().Pt() for part in hFromTauFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromH_pt'%self.label    , [ part.p4().Pt() for part in LFromTauFromH   ]) 
+        self.out.fillBranch('%sNuFromTauFromH_pt'%self.label   , [ part.p4().Pt() for part in NuFromTauFromH  ]) 
+        self.out.fillBranch('%sTNuFromTauFromH_pt'%self.label  , [ part.p4().Pt() for part in TNuFromTauFromH ]) 
+        self.out.fillBranch('%sZFromH_pt'%self.label           , [ part.p4().Pt() for part in ZFromH          ]) 
+        self.out.fillBranch('%sQFromZFromH_pt'%self.label      , [ part.p4().Pt() for part in QFromZFromH     ]) 
+        self.out.fillBranch('%sLFromZFromH_pt'%self.label      , [ part.p4().Pt() for part in LFromZFromH     ]) 
+        self.out.fillBranch('%sNuFromZFromH_pt'%self.label     , [ part.p4().Pt() for part in NuFromZFromH    ]) 
+        self.out.fillBranch('%sTauFromWFromH_pt'%self.label    , [ part.p4().Pt() for part in TauFromWFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromWFromH_pt'%self.label    , [ part.p4().Pt() for part in LFromTauFromWFromH    ]) 
+        self.out.fillBranch('%sNuFromTauFromWFromH_pt'%self.label   , [ part.p4().Pt() for part in NuFromTauFromWFromH   ]) 
+        self.out.fillBranch('%shFromTauFromWFromH_pt'%self.label    , [ part.p4().Pt() for part in hFromTauFromWFromH    ]) 
 
         self.out.fillBranch('%sHiggses_eta'%self.label          , [ part.p4().Eta() for part in Higgses         ]) 
         self.out.fillBranch('%sTfromhardprocess_eta'%self.label , [ part.p4().Eta() for part in Tfromhardprocess]) 
+        self.out.fillBranch('%sHadT_eta'%self.label             , [ part.p4().Eta() for part in HadT            ]) 
+        self.out.fillBranch('%sLepT_eta'%self.label             , [ part.p4().Eta() for part in LepT            ]) 
+        self.out.fillBranch('%sWFromHadT_eta'%self.label        , [ part.p4().Eta() for part in WFromHadT       ]) 
+        self.out.fillBranch('%sWFromLepT_eta'%self.label        , [ part.p4().Eta() for part in WFromLepT       ]) 
         self.out.fillBranch('%sWFromH_eta'%self.label           , [ part.p4().Eta() for part in WFromH          ]) 
+        self.out.fillBranch('%sHadWFromH_eta'%self.label        , [ part.p4().Eta() for part in HadWFromH       ]) 
         self.out.fillBranch('%sWFromT_eta'%self.label           , [ part.p4().Eta() for part in WFromT          ]) 
         self.out.fillBranch('%sQFromW_eta'%self.label           , [ part.p4().Eta() for part in QFromW          ]) 
         self.out.fillBranch('%sGenLep_eta'%self.label           , [ part.p4().Eta() for part in GenLep          ]) 
@@ -255,10 +463,28 @@ class HiggsDiffGenTTH(Module):
         self.out.fillBranch('%sQFromWFromT_eta'%self.label      , [ part.p4().Eta() for part in QFromWFromT     ]) 
         self.out.fillBranch('%sLFromWFromH_eta'%self.label      , [ part.p4().Eta() for part in LFromWFromH     ]) 
         self.out.fillBranch('%sLFromWFromT_eta'%self.label      , [ part.p4().Eta() for part in LFromWFromT     ]) 
+        self.out.fillBranch('%sTauFromH_eta'%self.label         , [ part.p4().Eta() for part in TauFromH        ]) 
+        self.out.fillBranch('%shFromTauFromH_eta'%self.label    , [ part.p4().Eta() for part in hFromTauFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromH_eta'%self.label    , [ part.p4().Eta() for part in LFromTauFromH   ]) 
+        self.out.fillBranch('%sNuFromTauFromH_eta'%self.label   , [ part.p4().Eta() for part in NuFromTauFromH  ]) 
+        self.out.fillBranch('%sTNuFromTauFromH_eta'%self.label  , [ part.p4().Eta() for part in TNuFromTauFromH ]) 
+        self.out.fillBranch('%sZFromH_eta'%self.label           , [ part.p4().Eta() for part in ZFromH          ]) 
+        self.out.fillBranch('%sQFromZFromH_eta'%self.label      , [ part.p4().Eta() for part in QFromZFromH     ]) 
+        self.out.fillBranch('%sLFromZFromH_eta'%self.label      , [ part.p4().Eta() for part in LFromZFromH     ]) 
+        self.out.fillBranch('%sNuFromZFromH_eta'%self.label     , [ part.p4().Eta() for part in NuFromZFromH    ]) 
+        self.out.fillBranch('%sTauFromWFromH_eta'%self.label    , [ part.p4().Eta() for part in TauFromWFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromWFromH_eta'%self.label    , [ part.p4().Eta() for part in LFromTauFromWFromH    ]) 
+        self.out.fillBranch('%sNuFromTauFromWFromH_eta'%self.label   , [ part.p4().Eta() for part in NuFromTauFromWFromH   ]) 
+        self.out.fillBranch('%shFromTauFromWFromH_eta'%self.label    , [ part.p4().Eta() for part in hFromTauFromWFromH    ]) 
 
         self.out.fillBranch('%sHiggses_phi'%self.label          , [ part.p4().Phi() for part in Higgses         ]) 
         self.out.fillBranch('%sTfromhardprocess_phi'%self.label , [ part.p4().Phi() for part in Tfromhardprocess]) 
+        self.out.fillBranch('%sHadT_phi'%self.label             , [ part.p4().Phi() for part in HadT            ]) 
+        self.out.fillBranch('%sLepT_phi'%self.label             , [ part.p4().Phi() for part in LepT            ]) 
+        self.out.fillBranch('%sWFromHadT_phi'%self.label        , [ part.p4().Phi() for part in WFromHadT       ]) 
+        self.out.fillBranch('%sWFromLepT_phi'%self.label        , [ part.p4().Phi() for part in WFromLepT       ]) 
         self.out.fillBranch('%sWFromH_phi'%self.label           , [ part.p4().Phi() for part in WFromH          ]) 
+        self.out.fillBranch('%sHadWFromH_phi'%self.label        , [ part.p4().Phi() for part in HadWFromH       ]) 
         self.out.fillBranch('%sWFromT_phi'%self.label           , [ part.p4().Phi() for part in WFromT          ]) 
         self.out.fillBranch('%sQFromW_phi'%self.label           , [ part.p4().Phi() for part in QFromW          ]) 
         self.out.fillBranch('%sGenLep_phi'%self.label           , [ part.p4().Phi() for part in GenLep          ]) 
@@ -269,10 +495,28 @@ class HiggsDiffGenTTH(Module):
         self.out.fillBranch('%sQFromWFromT_phi'%self.label      , [ part.p4().Phi() for part in QFromWFromT     ]) 
         self.out.fillBranch('%sLFromWFromH_phi'%self.label      , [ part.p4().Phi() for part in LFromWFromH     ]) 
         self.out.fillBranch('%sLFromWFromT_phi'%self.label      , [ part.p4().Phi() for part in LFromWFromT     ]) 
+        self.out.fillBranch('%sTauFromH_phi'%self.label         , [ part.p4().Phi() for part in TauFromH        ]) 
+        self.out.fillBranch('%shFromTauFromH_phi'%self.label    , [ part.p4().Phi() for part in hFromTauFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromH_phi'%self.label    , [ part.p4().Phi() for part in LFromTauFromH   ]) 
+        self.out.fillBranch('%sNuFromTauFromH_phi'%self.label   , [ part.p4().Phi() for part in NuFromTauFromH  ]) 
+        self.out.fillBranch('%sTNuFromTauFromH_phi'%self.label  , [ part.p4().Phi() for part in TNuFromTauFromH ]) 
+        self.out.fillBranch('%sZFromH_phi'%self.label           , [ part.p4().Phi() for part in ZFromH          ]) 
+        self.out.fillBranch('%sQFromZFromH_phi'%self.label      , [ part.p4().Phi() for part in QFromZFromH     ]) 
+        self.out.fillBranch('%sLFromZFromH_phi'%self.label      , [ part.p4().Phi() for part in LFromZFromH     ]) 
+        self.out.fillBranch('%sNuFromZFromH_phi'%self.label     , [ part.p4().Phi() for part in NuFromZFromH    ]) 
+        self.out.fillBranch('%sTauFromWFromH_phi'%self.label    , [ part.p4().Phi() for part in TauFromWFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromWFromH_phi'%self.label   , [ part.p4().Phi() for part in LFromTauFromWFromH    ]) 
+        self.out.fillBranch('%sNuFromTauFromWFromH_phi'%self.label  , [ part.p4().Phi() for part in NuFromTauFromWFromH   ]) 
+        self.out.fillBranch('%shFromTauFromWFromH_phi'%self.label   , [ part.p4().Phi() for part in hFromTauFromWFromH    ]) 
 
         self.out.fillBranch('%sHiggses_mass'%self.label          , [ part.p4().M() for part in Higgses         ]) 
         self.out.fillBranch('%sTfromhardprocess_mass'%self.label , [ part.p4().M() for part in Tfromhardprocess]) 
+        self.out.fillBranch('%sHadT_mass'%self.label             , [ part.p4().M() for part in HadT            ]) 
+        self.out.fillBranch('%sLepT_mass'%self.label             , [ part.p4().M() for part in LepT            ]) 
+        self.out.fillBranch('%sWFromHadT_mass'%self.label        , [ part.p4().M() for part in WFromHadT       ]) 
+        self.out.fillBranch('%sWFromLepT_mass'%self.label        , [ part.p4().M() for part in WFromLepT       ]) 
         self.out.fillBranch('%sWFromH_mass'%self.label           , [ part.p4().M() for part in WFromH          ]) 
+        self.out.fillBranch('%sHadWFromH_mass'%self.label        , [ part.p4().M() for part in HadWFromH       ]) 
         self.out.fillBranch('%sWFromT_mass'%self.label           , [ part.p4().M() for part in WFromT          ]) 
         self.out.fillBranch('%sQFromW_mass'%self.label           , [ part.p4().M() for part in QFromW          ]) 
         self.out.fillBranch('%sGenLep_mass'%self.label           , [ part.p4().M() for part in GenLep          ]) 
@@ -283,15 +527,40 @@ class HiggsDiffGenTTH(Module):
         self.out.fillBranch('%sQFromWFromT_mass'%self.label      , [ part.p4().M() for part in QFromWFromT     ]) 
         self.out.fillBranch('%sLFromWFromH_mass'%self.label      , [ part.p4().M() for part in LFromWFromH     ]) 
         self.out.fillBranch('%sLFromWFromT_mass'%self.label      , [ part.p4().M() for part in LFromWFromT     ]) 
+        self.out.fillBranch('%sTauFromH_mass'%self.label         , [ part.p4().M() for part in TauFromH        ]) 
+        self.out.fillBranch('%shFromTauFromH_mass'%self.label    , [ part.p4().M() for part in hFromTauFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromH_mass'%self.label    , [ part.p4().M() for part in LFromTauFromH   ]) 
+        self.out.fillBranch('%sNuFromTauFromH_mass'%self.label   , [ part.p4().M() for part in NuFromTauFromH  ]) 
+        self.out.fillBranch('%sTNuFromTauFromH_mass'%self.label  , [ part.p4().M() for part in TNuFromTauFromH ]) 
+        self.out.fillBranch('%sZFromH_mass'%self.label           , [ part.p4().M() for part in ZFromH          ]) 
+        self.out.fillBranch('%sQFromZFromH_mass'%self.label      , [ part.p4().M() for part in QFromZFromH     ]) 
+        self.out.fillBranch('%sLFromZFromH_mass'%self.label      , [ part.p4().M() for part in LFromZFromH     ]) 
+        self.out.fillBranch('%sNuFromZFromH_mass'%self.label     , [ part.p4().M() for part in NuFromZFromH    ]) 
+        self.out.fillBranch('%sTauFromWFromH_mass'%self.label    , [ part.p4().M() for part in TauFromWFromH   ]) 
+        self.out.fillBranch('%sLFromTauFromWFromH_mass'%self.label  , [ part.p4().M() for part in LFromTauFromWFromH    ]) 
+        self.out.fillBranch('%sNuFromTauFromWFromH_mass'%self.label , [ part.p4().M() for part in NuFromTauFromWFromH   ]) 
+        self.out.fillBranch('%shFromTauFromWFromH_mass'%self.label  , [ part.p4().M() for part in hFromTauFromWFromH    ]) 
 
         # Fill branches for some precomputed variables
         self.out.fillBranch('%spTHgen'%self.label, Higgses[0].p4().Pt() if len(Higgses)==1 else -99)
         self.out.fillBranch('%spTtgen'%self.label, [part.p4().Pt() for part in Tfromhardprocess] ) 
         self.out.fillBranch('%sinv_mass_q1_q2'%self.label, (QFromWFromH[0].p4()+QFromWFromH[1].p4()).M() if len(QFromWFromH)==2 else -99)
         self.out.fillBranch('%sdelR_partonsFromH'%self.label, QFromWFromH[0].p4().DeltaR(QFromWFromH[1].p4()) if len(QFromWFromH)==2 else -99)
+        self.out.fillBranch('%spt_partonsFromH'%self.label, (QFromWFromH[0].p4()+QFromWFromH[1].p4()).Pt() if len(QFromWFromH)==2 else -99)
 
         self.out.fillBranch('%squark1pT'%self.label, QFromWFromH[0].p4().Pt() if len(QFromWFromH)==2 else -99)
         self.out.fillBranch('%squark2pT'%self.label, QFromWFromH[1].p4().Pt() if len(QFromWFromH)==2 else -99)
+        self.out.fillBranch('%squark1Eta'%self.label, QFromWFromH[0].p4().Eta() if len(QFromWFromH)==2 else -99)
+        self.out.fillBranch('%squark2Eta'%self.label, QFromWFromH[1].p4().Eta() if len(QFromWFromH)==2 else -99)
+        q1pdgid = -99
+        q2pdgid = -99
+        if len(QFromWFromH)==2:
+#           q1pdgid = QFromWFromH[0].pdgId if QFromWFromH[0].pdgId == 4 or QFromWFromH[0].pdgId == 5 else 0
+#           q2pdgid = QFromWFromH[1].pdgId if QFromWFromH[1].pdgId == 4 or QFromWFromH[1].pdgId == 5 else 0
+            q1pdgid = QFromWFromH[0].pdgId
+            q2pdgid = QFromWFromH[1].pdgId
+        self.out.fillBranch('%squark1Flavour'%self.label, q1pdgid)
+        self.out.fillBranch('%squark2Flavour'%self.label, q2pdgid)
 
         if len(LFromWFromH)==1:
             self.out.fillBranch('%sdelR_H_q1l'%self.label, LFromWFromH[0].p4().DeltaR(QFromWFromH[0].p4()) if len(QFromWFromH)==2 else -99)
@@ -306,6 +575,7 @@ class HiggsDiffGenTTH(Module):
         if len(LFromWFromH)==1 and len(QFromWFromH)==2:
             trueVisibleHiggs = LFromWFromH[0].p4() + QFromWFromH[0].p4() + QFromWFromH[1].p4()
             self.out.fillBranch('%spTTrueGen'%self.label, trueVisibleHiggs.Pt())
+            self.out.fillBranch('%sMTrueGen'%self.label, trueVisibleHiggs.M())
             if len(NuFromWFromH)==1:
                 trueFullHiggs=trueVisibleHiggs+NuFromWFromH[0].p4()
                 self.out.fillBranch('%spTTrueGenPlusNu'%self.label, trueFullHiggs.Pt())
@@ -314,6 +584,7 @@ class HiggsDiffGenTTH(Module):
                 self.out.fillBranch('%spTTrueGenPlusNu'%self.label, -88)
         else:
             self.out.fillBranch('%spTTrueGen'%self.label, -99)
+            self.out.fillBranch('%sMTrueGen'%self.label, -99)
             self.out.fillBranch('%spTTrueGenPlusNu'%self.label, -99)
             
 

--- a/TTHAnalysis/python/tools/higgsDiffGenTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffGenTTH.py
@@ -554,8 +554,8 @@ class HiggsDiffGenTTH(Module):
         q1pdgid = -99
         q2pdgid = -99
         if len(QFromWFromH)==2:
-#           q1pdgid = QFromWFromH[0].pdgId if QFromWFromH[0].pdgId == 4 or QFromWFromH[0].pdgId == 5 else 0
-#           q2pdgid = QFromWFromH[1].pdgId if QFromWFromH[1].pdgId == 4 or QFromWFromH[1].pdgId == 5 else 0
+            #q1pdgid = QFromWFromH[0].pdgId if QFromWFromH[0].pdgId == 4 or QFromWFromH[0].pdgId == 5 else 0
+            #q2pdgid = QFromWFromH[1].pdgId if QFromWFromH[1].pdgId == 4 or QFromWFromH[1].pdgId == 5 else 0
             q1pdgid = QFromWFromH[0].pdgId
             q2pdgid = QFromWFromH[1].pdgId
         self.out.fillBranch('%squark1Flavour'%self.label, q1pdgid)

--- a/TTHAnalysis/python/tools/higgsDiffGenTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffGenTTH.py
@@ -104,7 +104,6 @@ class HiggsDiffGenTTH(Module):
         self.out.branch('%spTTrueGenPlusNu'%self.label   , 'F')
         
     def analyze(self, event):
-
         # Input collections and maps
         genpar = Collection(event,"GenPart","nGenPart") 
         

--- a/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
@@ -80,7 +80,6 @@ class HiggsDiffRecoTTH(Module):
             self.out.branch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)             , 'F')
             self.out.branch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)             , 'F')
 
-
     def analyze(self, event):
         # Some useful input parameters
         year=getattr(event,"year")
@@ -112,7 +111,6 @@ class HiggsDiffRecoTTH(Module):
             rightlep = ilist[0]
             wronglep = ilist[-1] # last element in list, usually ilist[1] since len(leps)==2 usually
 
-        
         for jesLabel in self.systsJEC.values():
             score = getattr(event,"BDThttTT_eventReco_mvaValue%s"%jesLabel)
             ljj_candidates=[];
@@ -208,10 +206,8 @@ class HiggsDiffRecoTTH(Module):
                     mHvisconstr = Hvisconstr.M()
                     pTHvisconstr = Hvisconstr.Pt()
                     #if mHvisconstr<self.cuts_mH_vis[0] or mHvisconstr>self.cuts_mH_vis[1]: continue
-
                     # Additional logic to experiment with different algorithms
                     lepchoice = 0 if _lep==goodlep else 1
-
                     # Store all non-rejected candidates
                     mindR = min(lep.DeltaR(j1),lep.DeltaR(j2))
                     delR_j1j2 = j1.DeltaR(j2)
@@ -296,7 +292,6 @@ class HiggsDiffRecoTTH(Module):
             self.out.fillBranch('%shtt_MWFromTop%s'%(self.label,jesLabel)  , htt_MWFromTop)
             self.out.fillBranch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)  , htt_HadTop_rightlep_delr)
             self.out.fillBranch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)  , htt_HadTop_wronglep_delr)
-
 
         return True
 

--- a/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
@@ -72,6 +72,14 @@ class HiggsDiffRecoTTH(Module):
             self.out.branch('%sfatJetsNearLeptonFromHiggs_tau3%s'%(self.label,jesLabel)      , 'F', 2, '%snFatJetsNearLeptonFromHiggs%s'%(self.label,jesLabel))
             self.out.branch('%sfatJetsNearLeptonFromHiggs_tau4%s'%(self.label,jesLabel)      , 'F', 2, '%snFatJetsNearLeptonFromHiggs%s'%(self.label,jesLabel))
 
+            # htt quantities
+            self.out.branch('%shtt_PtTop%s'%(self.label,jesLabel)                            , 'F')
+            self.out.branch('%shtt_MTop%s'%(self.label,jesLabel)                             , 'F')
+            self.out.branch('%shtt_PtWFromTop%s'%(self.label,jesLabel)                       , 'F')
+            self.out.branch('%shtt_MWFromTop%s'%(self.label,jesLabel)                        , 'F')
+            self.out.branch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)             , 'F')
+            self.out.branch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)             , 'F')
+
 
     def analyze(self, event):
         # Some useful input parameters
@@ -116,6 +124,13 @@ class HiggsDiffRecoTTH(Module):
             # Delicate: here the logic is built such that if one does not use the top tagger then 
             # some variables are left empty to suppress code into "if variable:" blocks
             # Bottom line is that when self.useTopTagger is False we iterate on all the non-b-jets
+            htt_PtTop = -99
+            htt_MTop  = -99
+            htt_PtWFromTop = -99
+            htt_MWFromTop  = -99
+            htt_HadTop_rightlep_delr = -99
+            htt_HadTop_wronglep_delr = -99
+            score = getattr(event,"BDThttTT_eventReco_mvaValue%s"%jesLabel)
             j1top = getattr(event,"BDThttTT_eventReco_iJetSel1%s"%jesLabel)
             j2top = getattr(event,"BDThttTT_eventReco_iJetSel2%s"%jesLabel)
             j3top = getattr(event,"BDThttTT_eventReco_iJetSel3%s"%jesLabel)
@@ -127,6 +142,19 @@ class HiggsDiffRecoTTH(Module):
                     jetsNoTopNoB = []
             else:
                 jetsNoTopNoB = [j for j in jets if j.btagDeepB<btagvetoval]
+            if score>self.cut_BDT_rTT_score and j1top >= 0 and j2top >= 0 and j3top >= 0:
+                j1 = jets[int(j1top)]
+                j2 = jets[int(j2top)]
+                j3 = jets[int(j3top)]
+                bscores = [j1.btagDeepB, j2.btagDeepB, j3.btagDeepB]
+                bindex = bscores.index(max(bscores))
+                htt_PtTop = (j1.p4()+j2.p4()+j3.p4()).Pt()
+                htt_MTop = (j1.p4()+j2.p4()+j3.p4()).M()
+                htt_PtWFromTop = (j1.p4()*(bindex!=0)+j2.p4()*(bindex!=1)+j3.p4()*(bindex!=2)).Pt()
+                htt_MWFromTop = (j1.p4()*(bindex!=0)+j2.p4()*(bindex!=1)+j3.p4()*(bindex!=2)).M()
+                if len(QFromWFromH)==2 and len(LFromWFromH)==1:
+                    htt_HadTop_rightlep_delr = (j1.p4()+j2.p4()+j3.p4()).DeltaR(leps[rightlep].p4())
+                    htt_HadTop_wronglep_delr = (j1.p4()+j2.p4()+j3.p4()).DeltaR(leps[wronglep].p4())
 
             # Additional logic to experiment with different algorithms
             goodlep = -99
@@ -260,6 +288,14 @@ class HiggsDiffRecoTTH(Module):
             #self.out.branch('%sfatJetsNearLeptonFromHiggs_tau2%s'%(self.label,jesLabel)      , 'F', 2, '%snLeptons%s'%(self.label,jesLabel))
             #self.out.branch('%sfatJetsNearLeptonFromHiggs_tau3%s'%(self.label,jesLabel)      , 'F', 2, '%snLeptons%s'%(self.label,jesLabel))
             #self.out.branch('%sfatJetsNearLeptonFromHiggs_tau4%s'%(self.label,jesLabel)      , 'F', 2, '%snLeptons%s'%(self.label,jesLabel))
+
+            # htt quantities
+            self.out.fillBranch('%shtt_PtTop%s'%(self.label,jesLabel)  , htt_PtTop)
+            self.out.fillBranch('%shtt_MTop%s'%(self.label,jesLabel)  , htt_MTop)
+            self.out.fillBranch('%shtt_PtWFromTop%s'%(self.label,jesLabel)  , htt_PtWFromTop)
+            self.out.fillBranch('%shtt_MWFromTop%s'%(self.label,jesLabel)  , htt_MWFromTop)
+            self.out.fillBranch('%shtt_HadTop_rightlep_delr%s'%(self.label,jesLabel)  , htt_HadTop_rightlep_delr)
+            self.out.fillBranch('%shtt_HadTop_wronglep_delr%s'%(self.label,jesLabel)  , htt_HadTop_wronglep_delr)
 
 
         return True

--- a/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
@@ -197,8 +197,7 @@ class HiggsDiffRecoTTH(Module):
                     # Optionally, later constrain the mass to the W PDG mass (although we use this only to build the candidate, and we store it without constraint)
                     W = j1+j2
                     mW = W.M()
-#                    if mW<self.cuts_mW_had[0] or mW>self.cuts_mW_had[1]: continue
-
+                    #if mW<self.cuts_mW_had[0] or mW>self.cuts_mW_had[1]: continue
                     Wconstr = W
                     if self.use_Wmass_constraint:
                         Wconstr = ROOT.TLorentzVector()
@@ -208,7 +207,7 @@ class HiggsDiffRecoTTH(Module):
                     Hvisconstr = lep+Wconstr
                     mHvisconstr = Hvisconstr.M()
                     pTHvisconstr = Hvisconstr.Pt()
-#                    if mHvisconstr<self.cuts_mH_vis[0] or mHvisconstr>self.cuts_mH_vis[1]: continue
+                    #if mHvisconstr<self.cuts_mH_vis[0] or mHvisconstr>self.cuts_mH_vis[1]: continue
 
                     # Additional logic to experiment with different algorithms
                     lepchoice = 0 if _lep==goodlep else 1

--- a/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
+++ b/TTHAnalysis/python/tools/higgsDiffRecoTTH.py
@@ -142,6 +142,7 @@ class HiggsDiffRecoTTH(Module):
                     jetsNoTopNoB = []
             else:
                 jetsNoTopNoB = [j for j in jets if j.btagDeepB<btagvetoval]
+
             if score>self.cut_BDT_rTT_score and j1top >= 0 and j2top >= 0 and j3top >= 0:
                 j1 = jets[int(j1top)]
                 j2 = jets[int(j2top)]
@@ -258,7 +259,7 @@ class HiggsDiffRecoTTH(Module):
 
             # Counters
             self.out.fillBranch('%snLeptonsFromHiggs%s'%(self.label,jesLabel), len(ls))
-            self.out.fillBranch('%snJetsFromHiggs%s'%(self.label,jesLabel)   , len(js))
+            self.out.fillBranch('%snJetsFromHiggs%s'%(self.label,jesLabel)   , len(js))    
             self.out.fillBranch('%snFO%s'%(self.label,jesLabel)              , nFO)
             self.out.fillBranch('%snJetsAfterCuts%s'%(self.label,jesLabel)   , len(jetsNoTopNoB))
 
@@ -322,5 +323,5 @@ higgsDiffRecoTTHLegacyTopTagger = lambda : HiggsDiffRecoTTH(label="Hreco_notopta
                                                             cut_BDT_rTT_score = 0.0,
                                                             cuts_mW_had = (60.,100.),
                                                             cuts_mH_vis = (80.,140.),
-                                                            btagDeepCSVveto = 'M', # or 'M'
+                                                            btagDeepCSVveto = 'M', # or 'M' or 'L' or 99
                                                             useTopTagger=True)

--- a/TTHAnalysis/python/tools/nanoAOD/ttH_modules.py
+++ b/TTHAnalysis/python/tools/nanoAOD/ttH_modules.py
@@ -437,7 +437,7 @@ from CMGTools.TTHAnalysis.tools.nanoAOD.ttH_gen_reco import ttH_gen_reco
 # TTH differential analysis
 from CMGTools.TTHAnalysis.tools.higgsDiffGenTTH import higgsDiffGenTTH
 from CMGTools.TTHAnalysis.tools.higgsDiffRecoTTH import higgsDiffRecoTTH, higgsDiffRecoTTH_noWmassConstraint
-from CMGTools.TTHAnalysis.tools.higgsDiffCompTTH import higgsDiffCompTTH
+from CMGTools.TTHAnalysis.tools.higgsDiffCompTTH import higgsDiffCompTTH, higgsDiffCompTTH_noWmassConstraint
 from CMGTools.TTHAnalysis.tools.higgsDiffRegressionTTH import higgsDiffRegressionTTH
 
 from CMGTools.TTHAnalysis.tools.nanoAOD.ttH_CP import ttH_CP


### PR DESCRIPTION
Here are the changes to the direct object reco algorithm files (diffHiggs*TTH.py) that were originally in PR #32. I'll close #32 now. I've addressed some of the comments from the old PR but things have changed around enough that its probably easiest to start a fresh review here and I can address comments directly on this PR